### PR TITLE
Add info icon and tooltip for image rating categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "13.2.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-icons": "^4.8.0",
         "styled-components": "^5.3.8",
         "uid": "^2.0.1"
       },
@@ -8311,6 +8312,14 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -15515,6 +15524,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-icons": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.8.0.tgz",
+      "integrity": "sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "13.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-icons": "^4.8.0",
     "styled-components": "^5.3.8",
     "uid": "^2.0.1"
   },

--- a/pages/components/ImageList.js
+++ b/pages/components/ImageList.js
@@ -27,6 +27,7 @@ const ImageListWrapper = styled.div`
   background: linear-gradient(to bottom, #444444, #ffffff);
 `;
 
+// Create an ImageList functional component that will return a list of images displayed inside the ImageListWrapper component
 const ImageList = () => {
   // create an array of images with their source and id
   const images = Array.from({ length: 20 }, (_, i) => ({

--- a/pages/image/[id].js
+++ b/pages/image/[id].js
@@ -2,6 +2,7 @@ import Image from "next/legacy/image";
 import { useRouter } from "next/router";
 import styled from "styled-components";
 import { useState, useEffect } from "react";
+import { FiInfo } from "react-icons/fi";
 
 const ButtonWrapper = styled.div`
   display: flex;
@@ -16,6 +17,7 @@ const SliderButton = styled.button`
   background-color: #4caf50;
   color: #ffffff;
   margin-bottom: 20px;
+  margin-top: 10px;
   font-size: 16px;
   font-weight: bold;
   border-radius: 10px;
@@ -40,7 +42,7 @@ const RangeInput = styled.input`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 300px;
+  width: 200px;
   margin: 5px;
   margin-bottom: 10px;
   -webkit-appearance: none;
@@ -71,6 +73,52 @@ const RangeInput = styled.input`
   }
 `;
 
+const InfoIcon = styled(FiInfo)`
+  margin: auto;
+  font-size: 30px;
+  color: #ffcc00;
+  transition: transform 0.2s ease-in-out, color 0.4s ease-in-out;
+
+  &:hover {
+    transform: scale(1.1);
+    cursor: pointer;
+    color: #ffffff;
+  }
+
+  &:active {
+    color: #000000;
+  }
+`;
+
+const TooltipContainer = styled.div`
+  position: relative;
+  display: inline-block;
+  cursor: help;
+`;
+
+const TooltipText = styled.div`
+  visibility: ${(props) => (props.show ? "visible" : "hidden")};
+  width: 370px;
+  height: auto;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 10px;
+  position: absolute;
+  z-index: 1;
+  opacity: 1;
+  font-size: 18px;
+  transition: visibility 0.3s, opacity 0.3s;
+  top: 23px;
+  left: 50%;
+  transform: translate(-50%, -100%);
+
+  strong {
+    color: #ffcc00;
+  }
+`;
+
 const ImagePage = () => {
   const router = useRouter(); // Initializing the useRouter hook
   const { id } = router.query; // Extracting the 'id' parameter from the router query
@@ -78,6 +126,12 @@ const ImagePage = () => {
 
   // Initializing state for the range values
   const [rangeValues, setRangeValues] = useState([0, 0, 0, 0, 0]);
+
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const toggleTooltip = () => {
+    setShowTooltip(!showTooltip);
+  };
 
   useEffect(() => {
     // Retrieving range values from local storage
@@ -126,9 +180,43 @@ const ImagePage = () => {
         objectFit="contain"
         layout="intrinsic"
       />
+      <>
+        <TooltipContainer
+          onMouseEnter={toggleTooltip}
+          onMouseLeave={toggleTooltip}
+        >
+          <InfoIcon />
+          <TooltipText show={showTooltip}>
+            <strong>Creativity:</strong>
+            <br />
+            Measures the uniqueness and originality of the AI-generated image.
+            <br />
+            <br />
+            <strong>Technical Quality:</strong>
+            <br /> Evaluates the level of detail, clarity, and overall
+            craftsmanship of the image.
+            <br />
+            <br />
+            <strong>Emotional Impact:</strong>
+            <br /> Considers how well the image captures and conveys an
+            emotional tone or atmosphere.
+            <br />
+            <br />
+            <strong>Coherence:</strong>
+            <br /> Determines how well the various elements of the image fit
+            together harmoniously.
+            <br />
+            <br />
+            <strong>Realism:</strong>
+            <br /> Gauges how accurately and convincingly the image represents
+            its subject matter.
+            <br />
+          </TooltipText>
+        </TooltipContainer>
+      </>
       <div>
         <div>
-          <SliderLabel htmlFor="slider1">Slider 1</SliderLabel>
+          <SliderLabel htmlFor="slider1">Creativity</SliderLabel>
           <RangeInput
             type="range"
             id="slider1"
@@ -139,7 +227,7 @@ const ImagePage = () => {
           />
         </div>
         <div>
-          <SliderLabel htmlFor="slider2">Slider 2</SliderLabel>
+          <SliderLabel htmlFor="slider2">Technical Quality</SliderLabel>
           <RangeInput
             type="range"
             id="slider2"
@@ -150,7 +238,7 @@ const ImagePage = () => {
           />
         </div>
         <div>
-          <SliderLabel htmlFor="slider3">Slider 3</SliderLabel>
+          <SliderLabel htmlFor="slider3">Emotional Impact</SliderLabel>
           <RangeInput
             type="range"
             id="slider3"
@@ -161,7 +249,7 @@ const ImagePage = () => {
           />
         </div>
         <div>
-          <SliderLabel htmlFor="slider4">Slider 4</SliderLabel>
+          <SliderLabel htmlFor="slider4">Coherence</SliderLabel>
           <RangeInput
             type="range"
             id="slider4"
@@ -172,7 +260,7 @@ const ImagePage = () => {
           />
         </div>
         <div>
-          <SliderLabel htmlFor="slider5">Slider 5</SliderLabel>
+          <SliderLabel htmlFor="slider5">Realism</SliderLabel>
           <RangeInput
             type="range"
             id="slider5"

--- a/pages/image/[id].js
+++ b/pages/image/[id].js
@@ -110,7 +110,7 @@ const TooltipText = styled.div`
   opacity: 1;
   font-size: 18px;
   transition: visibility 0.3s, opacity 0.3s;
-  top: 23px;
+  top: 30px;
   left: 50%;
   transform: translate(-50%, -100%);
 
@@ -120,19 +120,27 @@ const TooltipText = styled.div`
 `;
 
 const ImagePage = () => {
-  const router = useRouter(); // Initializing the useRouter hook
-  const { id } = router.query; // Extracting the 'id' parameter from the router query
-  const imageUrl = `/image${id}.png`; // Generating the URL for the image to be displayed
+  // Importing router hook for navigation within the app
+  const router = useRouter();
 
-  // Initializing state for the range values
+  // Extracting the 'id' parameter from the router query
+  const { id } = router.query;
+
+  // Generating the URL for the image to be displayed
+  const imageUrl = `/image${id}.png`;
+
+  // Initializing state for the range values using the 'useState' hook
   const [rangeValues, setRangeValues] = useState([0, 0, 0, 0, 0]);
 
+  // Initializing true/false state for displaying/hiding tooltips
   const [showTooltip, setShowTooltip] = useState(false);
 
+  // Toggles between display/hide of tooltips
   const toggleTooltip = () => {
     setShowTooltip(!showTooltip);
   };
 
+  // useEffect hook - Runs on the initialization of the component, extracts and updates the saved range values from Local Storage.
   useEffect(() => {
     // Retrieving range values from local storage
     const savedRangeValues = JSON.parse(localStorage.getItem("rangeValues"));
@@ -172,6 +180,8 @@ const ImagePage = () => {
 
   return (
     <ImagePageWrapper>
+      {/* Next.js image component dynamically passes the URL of the image given the
+      id parameter extracted above. */}
       <Image
         src={imageUrl}
         alt={`My Image ${id}`}
@@ -181,6 +191,7 @@ const ImagePage = () => {
         layout="intrinsic"
       />
       <>
+        {/* Tooltip element shown when InfoIcon is hovered over */}
         <TooltipContainer
           onMouseEnter={toggleTooltip}
           onMouseLeave={toggleTooltip}
@@ -214,6 +225,7 @@ const ImagePage = () => {
           </TooltipText>
         </TooltipContainer>
       </>
+      {/* Displays sliders for user ratings and enables rating inputs using 'handleRangeChange' function defined above */}
       <div>
         <div>
           <SliderLabel htmlFor="slider1">Creativity</SliderLabel>
@@ -271,6 +283,7 @@ const ImagePage = () => {
           />
         </div>
       </div>
+      {/* Button container to navigate back to the previous page and to save ratings. */}
       <ButtonWrapper>
         <SliderButton onClick={() => router.back()}>Back</SliderButton>
         <SliderButton onClick={handleSave}>Save</SliderButton>

--- a/pages/image/[id].js
+++ b/pages/image/[id].js
@@ -98,25 +98,27 @@ const TooltipContainer = styled.div`
 
 const TooltipText = styled.div`
   visibility: ${(props) => (props.show ? "visible" : "hidden")};
-  width: 370px;
+  width: 350px;
   height: auto;
   background-color: #333;
   color: #fff;
   text-align: center;
   border-radius: 6px;
-  padding: 10px;
   position: absolute;
-  z-index: 1;
-  opacity: 1;
-  font-size: 18px;
-  transition: visibility 0.3s, opacity 0.3s;
-  top: 30px;
   left: 50%;
   transform: translate(-50%, -100%);
+`;
 
-  strong {
-    color: #ffcc00;
-  }
+const TooltipTitle = styled.h2`
+  font-size: 18px;
+  font-weight: bold;
+  color: #ffcc00;
+`;
+
+const TooltipTextItem = styled.p`
+  font-size: 14px;
+  margin-bottom: 20px;
+  margin-top: -10px;
 `;
 
 const ImagePage = () => {
@@ -198,30 +200,30 @@ const ImagePage = () => {
         >
           <InfoIcon />
           <TooltipText show={showTooltip}>
-            <strong>Creativity:</strong>
-            <br />
-            Measures the uniqueness and originality of the AI-generated image.
-            <br />
-            <br />
-            <strong>Technical Quality:</strong>
-            <br /> Evaluates the level of detail, clarity, and overall
-            craftsmanship of the image.
-            <br />
-            <br />
-            <strong>Emotional Impact:</strong>
-            <br /> Considers how well the image captures and conveys an
-            emotional tone or atmosphere.
-            <br />
-            <br />
-            <strong>Coherence:</strong>
-            <br /> Determines how well the various elements of the image fit
-            together harmoniously.
-            <br />
-            <br />
-            <strong>Realism:</strong>
-            <br /> Gauges how accurately and convincingly the image represents
-            its subject matter.
-            <br />
+            <TooltipTitle>Creativity:</TooltipTitle>
+            <TooltipTextItem>
+              Measures the uniqueness and originality of the AI-generated image.
+            </TooltipTextItem>
+            <TooltipTitle>Technical Quality:</TooltipTitle>
+            <TooltipTextItem>
+              Evaluates the level of detail, clarity, and overall craftsmanship
+              of the image.
+            </TooltipTextItem>
+            <TooltipTitle>Emotional Impact:</TooltipTitle>
+            <TooltipTextItem>
+              Considers how well the image captures and conveys an emotional
+              tone or atmosphere.
+            </TooltipTextItem>
+            <TooltipTitle>Coherence:</TooltipTitle>
+            <TooltipTextItem>
+              Determines how well the various elements of the image fit together
+              harmoniously.
+            </TooltipTextItem>
+            <TooltipTitle>Realism:</TooltipTitle>
+            <TooltipTextItem>
+              Gauges how accurately and convincingly the image represents its
+              subject matter.
+            </TooltipTextItem>
           </TooltipText>
         </TooltipContainer>
       </>

--- a/pages/image/[id].js
+++ b/pages/image/[id].js
@@ -79,14 +79,13 @@ const InfoIcon = styled(FiInfo)`
   color: #ffcc00;
   transition: transform 0.2s ease-in-out, color 0.4s ease-in-out;
 
-  &:hover {
-    transform: scale(1.1);
-    cursor: pointer;
+  &:active {
+    transform: scale(2);
     color: #ffffff;
   }
 
-  &:active {
-    color: #000000;
+  &:focus {
+    outline: none;
   }
 `;
 
@@ -105,18 +104,19 @@ const TooltipText = styled.div`
   text-align: center;
   border-radius: 6px;
   position: absolute;
+  top: -10px;
   left: 50%;
   transform: translate(-50%, -100%);
 `;
 
 const TooltipTitle = styled.h2`
-  font-size: 18px;
+  font-size: 16px;
   font-weight: bold;
   color: #ffcc00;
 `;
 
 const TooltipTextItem = styled.p`
-  font-size: 14px;
+  font-size: 12px;
   margin-bottom: 20px;
   margin-top: -10px;
 `;
@@ -197,6 +197,9 @@ const ImagePage = () => {
         <TooltipContainer
           onMouseEnter={toggleTooltip}
           onMouseLeave={toggleTooltip}
+          onFocus={toggleTooltip}
+          onBlur={toggleTooltip}
+          tabIndex="0"
         >
           <InfoIcon />
           <TooltipText show={showTooltip}>


### PR DESCRIPTION
This commit adds an info icon next to the image and implements a tooltip functionality that displays brief descriptions of the five best image evaluation/rating categories when the user clicks on the icon. Each category is clearly labeled with a name to help the user better understand how to evaluate the image. The tooltip disappears when the user clicks outside of it. This feature enhances user experience by providing them with more information on how to evaluate the image.

--> [US](https://github.com/users/CTGitWhiz/projects/1/views/1?pane=issue&itemId=22734482) 